### PR TITLE
Fix missing separator for sample rate

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -398,6 +398,7 @@ func (c *Client) appendRate(rate float32) {
 		c.rateCache = make(map[float32]string)
 	}
 
+	c.appendByte('|')
 	c.appendByte('@')
 	if s, ok := c.rateCache[rate]; ok {
 		c.appendString(s)

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -89,7 +89,7 @@ func TestUnique(t *testing.T) {
 }
 
 func TestSamplingRate(t *testing.T) {
-	testOutput(t, "test_key:3|c@0.6\ntest_key:4|ms@0.6", func(c *Client) {
+	testOutput(t, "test_key:3|c|@0.6\ntest_key:4|ms|@0.6", func(c *Client) {
 		randFloat = func() float32 { return 0.5 }
 		c.Count(testKey, 1, 0.2)
 		c.Timing(testKey, 2, 0.3)


### PR DESCRIPTION
Just a quick patch to fix the current appendRate(), which currently is missing the pipe character before `@`. 

Based off:  https://github.com/b/statsd_spec as well as http://docs.datadoghq.com/guides/dogstatsd/
