### PR TITLE
Add support for histogram metrics

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -280,6 +280,26 @@ func (c *Client) gauge(value int) {
 	c.closeMetric()
 }
 
+// Histogram sends a histogram value to a bucket with the given sampling rate.
+func (c *Client) Histogram(bucket string, value int, rate float32) {
+	if c.muted {
+		return
+	}
+	if isRandAbove(rate) {
+		return
+	}
+
+	c.mu.Lock()
+	l := len(c.buf)
+	c.appendBucket(bucket)
+	c.appendInt(value)
+	c.appendType("h")
+	c.appendRate(rate)
+	c.closeMetric()
+	c.flushIfBufferFull(l)
+	c.mu.Unlock()
+}
+
 // Timing sends a timing value to a bucket with the given sampling rate.
 func (c *Client) Timing(bucket string, value int, rate float32) {
 	if c.muted {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -45,6 +45,12 @@ func TestChangeGauge(t *testing.T) {
 	})
 }
 
+func TestHistogram(t *testing.T) {
+	testOutput(t, "test_key:10|h", func(c *Client) {
+		c.Histogram(testKey, 10, 1)
+	})
+}
+
 func TestTiming(t *testing.T) {
 	testOutput(t, "test_key:6|ms", func(c *Client) {
 		c.Timing(testKey, 6, 1)


### PR DESCRIPTION
Histograms are supported by a few statsd implementations such as [datadog](http://docs.datadoghq.com/guides/metrics/) and [sysdig](http://support.sysdigcloud.com/hc/en-us/articles/204376099-Metrics-Configuration-StatsD-). They're essentially special case Timing for generic histogram measurements like file sizes.

Totally understand if you want to keep your statsd library purely upstream supported statsd metrics. Just something useful for our case (we use sysdig).
