### PR TITLE
Remove "quick listener check" and don't mute connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -45,18 +45,6 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	if err != nil {
 		return c, err
 	}
-	// When using UDP do a quick check to see if something is listening on the
-	// given port to return an error as soon as possible.
-	if c.network[:3] == "udp" {
-		for i := 0; i < 2; i++ {
-			_, err = c.w.Write(nil)
-			if err != nil {
-				_ = c.w.Close()
-				c.w = nil
-				return c, err
-			}
-		}
-	}
 
 	// To prevent a buffer overflow add some capacity to the buffer to allow for
 	// an additional metric.


### PR DESCRIPTION
Commit removes "quick listener check" which mutes connection and returns error
when listener isn't available at the time of inicialization.
It seems as this there is no need to scrap connection, because when remote
endpoint comes around later, metrics will be received by that endpoint just
fine.

Fixes #6
