### PR TITLE
Fixed func Address example

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -62,7 +62,7 @@ func ExampleClient_Clone() {
 }
 
 func ExampleAddress() {
-	c, err = statsd.New(statsd.Address("192.168.0.5:8126"))
+	c, err = statsd.New(statsd.Address("192.168.0.5:8125"))
 }
 
 func ExampleErrorHandler() {


### PR DESCRIPTION
In case someone is copy pasting from the example, it makes sense for the
documentation to use the standard port 8125 instead of the
administrative port 8126.