### PR TITLE
Add AbsolutePrefix Option

### DIFF
--- a/options.go
+++ b/options.go
@@ -113,6 +113,20 @@ func Prefix(p string) Option {
 	})
 }
 
+// AbsolutePrefix defines the prefix that will be used in every bucket name.
+//
+// If this is used in conjunction with Prefix(...), the results will depend
+// on the ordering of the two options.
+//
+// Note that when used in cloned, the absolute prefix will override the prefix
+// of the parent Client.
+func AbsolutePrefix(p string) Option {
+	return Option(func(c *config) {
+		c.Client.Prefix = strings.TrimSuffix(p, ".") + "."
+	})
+}
+
+
 // TagFormat represents the format of tags sent by a Client.
 type TagFormat uint8
 

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -161,6 +161,12 @@ func TestPrefix(t *testing.T) {
 	}, Prefix("foo"))
 }
 
+func TestAbsolutePrefix(t *testing.T) {
+	testOutput(t, "foo.test_key:1|c", func(c *Client) {
+		c.Increment(testKey)
+	}, AbsolutePrefix("foo"))
+}
+
 func TestNilTags(t *testing.T) {
 	testOutput(t, "test_key:1|c", func(c *Client) {
 		c.Increment(testKey)
@@ -306,6 +312,12 @@ func TestMuteClone(t *testing.T) {
 func TestClonePrefix(t *testing.T) {
 	testOutput(t, "app.http.test_key:5|c", func(c *Client) {
 		c.Clone(Prefix("http")).Count(testKey, 5)
+	}, Prefix("app"))
+}
+
+func TestCloneAbsolutePrefix(t *testing.T) {
+	testOutput(t, "http.test_key:5|c", func(c *Client) {
+		c.Clone(AbsolutePrefix("http")).Count(testKey, 5)
 	}, Prefix("app"))
 }
 


### PR DESCRIPTION
This change attempts to be able to clone a statsd client, by providing a fresh prefix, which is not tied to any parent prefixes. 