### PR TITLE
Add GaugeRelative to support Telegraf statsd implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - tip
+  - 1.x
+  - master
+
+install:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.6
+
+script:
+  - go test -v -race -timeout=10s ./...
+  - golangci-lint run

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 statsd is a simple and efficient [Statsd](https://github.com/etsy/statsd)
 client.
 
+This is a fork of a [dead statsd client project](https://github.com/alexcesaro/statsd) with various impprovements.
+
 See the [benchmark](https://github.com/alexcesaro/statsdbench) for a comparison
 with other Go StatsD clients.
 
@@ -27,7 +29,7 @@ https://godoc.org/gopkg.in/alexcesaro/statsd.v2
 
 ## Download
 
-    go get gopkg.in/alexcesaro/statsd.v2
+    go get github.com/multiplay/statsd
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # statsd
-[![Build Status](https://travis-ci.org/alexcesaro/statsd.svg?branch=v2)](https://travis-ci.org/alexcesaro/statsd) [![Code Coverage](http://gocover.io/_badge/gopkg.in/alexcesaro/statsd.v2)](http://gocover.io/gopkg.in/alexcesaro/statsd.v2) [![Documentation](https://godoc.org/gopkg.in/alexcesaro/statsd.v2?status.svg)](https://godoc.org/gopkg.in/alexcesaro/statsd.v2)
 
 ## Introduction
 
@@ -8,34 +7,17 @@ client.
 
 This is a fork of a [dead statsd client project](https://github.com/alexcesaro/statsd) with various impprovements.
 
-See the [benchmark](https://github.com/alexcesaro/statsdbench) for a comparison
-with other Go StatsD clients.
-
 ## Features
 
-- Supports all StatsD metrics: counter, gauge, timing and set
+- Supports all StatsD metrics: counter, gauge (absolute and relative), timing and set
 - Supports InfluxDB and Datadog tags
 - Fast and GC-friendly: all functions for sending metrics do not allocate
 - Efficient: metrics are buffered by default
 - Simple and clean API
-- 100% test coverage
-- Versioned API using gopkg.in
-
-
-## Documentation
-
-https://godoc.org/gopkg.in/alexcesaro/statsd.v2
-
 
 ## Download
 
     go get github.com/multiplay/statsd
-
-
-## Example
-
-See the [examples in the documentation](https://godoc.org/gopkg.in/alexcesaro/statsd.v2#example-package).
-
 
 ## License
 
@@ -47,6 +29,4 @@ See the [examples in the documentation](https://godoc.org/gopkg.in/alexcesaro/st
 Do you have any question the documentation does not answer? Is there a use case
 that you feel is common and is not well-addressed by the current API?
 
-If so you are more than welcome to ask questions in the
-[thread on golang-nuts](https://groups.google.com/d/topic/golang-nuts/Tz6t4_iLgnw/discussion)
-or open an issue or send a pull-request here on Github.
+If so you are more than welcome to ask questions or open an issue or send a pull-request here on Github.

--- a/conn.go
+++ b/conn.go
@@ -54,7 +54,7 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	if c.flushPeriod > 0 {
 		go func() {
 			ticker := time.NewTicker(c.flushPeriod)
-			for _ = range ticker.C {
+			for range ticker.C {
 				c.mu.Lock()
 				if c.closed {
 					ticker.Stop()
@@ -92,6 +92,7 @@ func (c *conn) gaugeRelative(prefix, bucket string, value interface{}, tags stri
 		c.appendString(fmt.Sprintf("+%v", value))
 	}
 	c.appendType("g")
+	c.closeMetric(tags)
 	c.flushIfBufferFull(l)
 	c.mu.Unlock()
 }
@@ -170,23 +171,23 @@ func isNegative(v interface{}) bool {
 	case int:
 		return n < 0
 	case uint:
-		return n < 0
+		return false
 	case int64:
 		return n < 0
 	case uint64:
-		return n < 0
+		return false
 	case int32:
 		return n < 0
 	case uint32:
-		return n < 0
+		return false
 	case int16:
 		return n < 0
 	case uint16:
-		return n < 0
+		return false
 	case int8:
 		return n < 0
 	case uint8:
-		return n < 0
+		return false
 	case float64:
 		return n < 0
 	case float32:

--- a/conn.go
+++ b/conn.go
@@ -46,18 +46,6 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	if err != nil {
 		return c, err
 	}
-	// When using UDP do a quick check to see if something is listening on the
-	// given port to return an error as soon as possible.
-	if c.network[:3] == "udp" {
-		for i := 0; i < 2; i++ {
-			_, err = c.w.Write(nil)
-			if err != nil {
-				_ = c.w.Close()
-				c.w = nil
-				return c, err
-			}
-		}
-	}
 
 	// To prevent a buffer overflow add some capacity to the buffer to allow for
 	// an additional metric.

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"gopkg.in/alexcesaro/statsd.v2"
+	"github.com/multiplay/statsd"
 )
 
 var (

--- a/statsd.go
+++ b/statsd.go
@@ -100,6 +100,14 @@ func (c *Client) Gauge(bucket string, value interface{}) {
 	c.conn.gauge(c.prefix, bucket, value, c.tags)
 }
 
+// GaugeRelative records an relative value for the given bucket.
+func (c *Client) GaugeRelative(bucket string, value interface{}) {
+	if c.skip() {
+		return
+	}
+	c.conn.gaugeRelative(c.prefix, bucket, value, c.tags)
+}
+
 // Timing sends a timing value to a bucket.
 func (c *Client) Timing(bucket string, value interface{}) {
 	if c.skip() {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -37,6 +37,13 @@ func TestGauge(t *testing.T) {
 	})
 }
 
+func TestGaugeRelative(t *testing.T) {
+	testOutput(t, "test_key:+5|g\ntest_key:-10|g", func(c *Client) {
+		c.GaugeRelative(testKey, 5)
+		c.GaugeRelative(testKey, -10)
+	})
+}
+
 func TestTiming(t *testing.T) {
 	testOutput(t, "test_key:6|ms", func(c *Client) {
 		c.Timing(testKey, 6)
@@ -357,40 +364,6 @@ func TestConcurrency(t *testing.T) {
 		c.Increment(testKey)
 		wg.Wait()
 	})
-}
-
-func TestUDPNotListening(t *testing.T) {
-	dialTimeout = mockUDPClosed
-	defer func() { dialTimeout = net.DialTimeout }()
-
-	c, err := New()
-	if c == nil || !c.muted {
-		t.Error("New() did not return a muted client")
-	}
-	if err == nil {
-		t.Error("New should return an error")
-	}
-}
-
-type mockClosedUDPConn struct {
-	i int
-	net.Conn
-}
-
-func (c *mockClosedUDPConn) Write(p []byte) (int, error) {
-	c.i++
-	if c.i == 2 {
-		return 0, errors.New("test error")
-	}
-	return 0, nil
-}
-
-func (c *mockClosedUDPConn) Close() error {
-	return nil
-}
-
-func mockUDPClosed(string, string, time.Duration) (net.Conn, error) {
-	return &mockClosedUDPConn{}, nil
 }
 
 func testClient(t *testing.T, f func(*Client), options ...Option) {


### PR DESCRIPTION
Telegraf doesn't support support negative counters, requiring relative gauge values instead. This adds the new method GaugeRelative to allow for this.