### PR TITLE
Clone does not correctly overwrite tags

### DIFF
--- a/options.go
+++ b/options.go
@@ -148,10 +148,10 @@ func Tags(tags ...string) Option {
 
 		for _, newTag := range newTags {
 			exists := false
-			for _, oldTag := range c.Client.Tags {
-				if newTag.K == oldTag.K {
+			for j, _ := range c.Client.Tags {
+				if newTag.K == c.Client.Tags[j].K {
 					exists = true
-					oldTag.V = newTag.V
+					c.Client.Tags[j].V = newTag.V
 				}
 			}
 			if !exists {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -317,14 +317,14 @@ func TestCloneRate(t *testing.T) {
 }
 
 func TestCloneInfluxDBTags(t *testing.T) {
-	testOutput(t, "test_key,tag1=value1,tag2=value2:5|c", func(c *Client) {
+	testOutput(t, "test_key,tag1=value3,tag2=value2:5|c", func(c *Client) {
 		clone := c.Clone(Tags("tag1", "value3", "tag2", "value2"))
 		clone.Count(testKey, 5)
 	}, TagsFormat(InfluxDB), Tags("tag1", "value1"))
 }
 
 func TestCloneDatadogTags(t *testing.T) {
-	testOutput(t, "test_key:5|c|#tag1:value1,tag2:value2", func(c *Client) {
+	testOutput(t, "test_key:5|c|#tag1:value3,tag2:value2", func(c *Client) {
 		clone := c.Clone(Tags("tag1", "value3", "tag2", "value2"))
 		clone.Count(testKey, 5)
 	}, TagsFormat(Datadog), Tags("tag1", "value1"))


### PR DESCRIPTION
When doing a `Clone` operation and overwriting a tag, the tag is not correctly overwritten. 

This is because we are doing a `range` over the client tags and overwriting a copy of the Tag struct when you do `range` rather than the original value