### PR TITLE
feat: Client.Muted()

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -75,6 +75,11 @@ func (c *Client) Clone(opts ...Option) *Client {
 	return clone
 }
 
+// Muted tells whether this Client is muted or not.
+func (c *Client) Muted() bool {
+	return c.muted
+}
+
 // Count adds n to bucket.
 func (c *Client) Count(bucket string, n interface{}) {
 	if c.skip() {


### PR DESCRIPTION
It can be useful to know whether a Client is muted or not to avoid complex metrics code wiring using a Client that is already a noop one.

This is just for the sake of performance when metrics recording is disabled.
