### PR TITLE
Timing() time.Duration support

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -105,6 +105,9 @@ func (c *Client) Timing(bucket string, value interface{}) {
 	if c.skip() {
 		return
 	}
+	if v, ok := value.(time.Duration); ok {
+		value = int64(v / time.Millisecond)
+	}
 	c.conn.metric(c.prefix, bucket, value, "ms", c.rate, c.tags)
 }
 
@@ -129,7 +132,7 @@ func (c *Client) NewTiming() Timing {
 
 // Send sends the time elapsed since the creation of the Timing.
 func (t Timing) Send(bucket string) {
-	t.c.Timing(bucket, int(t.Duration()/time.Millisecond))
+	t.c.Timing(bucket, t.Duration())
 }
 
 // Duration returns the time elapsed since the creation of the Timing.

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -43,6 +43,12 @@ func TestTiming(t *testing.T) {
 	})
 }
 
+func TestTimingDuration(t *testing.T) {
+	testOutput(t, "test_key:7|ms", func(c *Client) {
+		c.Timing(testKey, time.Duration(7*time.Millisecond))
+	})
+}
+
 func TestHistogram(t *testing.T) {
 	testOutput(t, "test_key:17|h", func(c *Client) {
 		c.Histogram(testKey, 17)


### PR DESCRIPTION
Sometimes `Timing` struct cannot be used because duration to record is known using a starting date coming from another context (DB or whatever).

When using `Client.Timing` method, caller has to manually redo the int64 casting/millisecond truncating by hand because time.Duration is not supported.

ex:
```go
startDate := ... // some time.Time coming from another context
client.Timing(int64(time.Now().Sub(startDate)/time.Millisecond))
```

a simpler alternative would be
```go
client.Timing(time.Now().Sub(startDate))
```
